### PR TITLE
Fix error of nested test

### DIFF
--- a/src/__tests__/Todo.test.js
+++ b/src/__tests__/Todo.test.js
@@ -3,29 +3,27 @@ import { render, fireEvent } from "@testing-library/react";
 import Todo from "../Todo";
 import "@testing-library/jest-dom/extend-expect";
 
-test("Todo", () => {
-  it("displays initial to-dos", () => {
-    const { getByTestId } = render(<Todo />);
-    const todos = getByTestId("todos");
-    expect(todos.children.length).toBe(2);
-  });
-
-  it("adds a new to-do", () => {
-    const { getByTestId, getByText } = render(<Todo />);
-    const input = getByTestId("input");
-    const todos = getByTestId("todos");
-
-    input.value = "Fix failing tests";
-    fireEvent.click(getByText("Add Task"));
-    expect(todos.children.length).toBe(3);
-  });
-
-  it("deletes a to-do", () => {
-    const { getAllByTestId, getByTestId } = render(<Todo />);
-    const todos = getByTestId("todos");
-    const deleteButton = getAllByTestId("delete-button");
-    const first = deleteButton[0];
-    fireEvent.click(first);
-    expect(todos.children.length).toBe(1);
-  });
+test("displays initial to-dos", () => {
+  const { getByTestId } = render(<Todo />);
+  const todos = getByTestId("todos");
+  expect(todos.children.length).toBe(2);
 });
+
+test("adds a new to-do", () => {
+  const { getByTestId, getByText } = render(<Todo />);
+  const input = getByTestId("input");
+  const todos = getByTestId("todos");
+
+  input.value = "Fix failing tests";
+  fireEvent.click(getByText("Add Task"));
+  expect(todos.children.length).toBe(3);
+});
+test("deletes a to-do", () => {
+  const { getAllByTestId, getByTestId } = render(<Todo />);
+  const todos = getByTestId("todos");
+  const deleteButton = getAllByTestId("delete-button");
+  const first = deleteButton[0];
+  fireEvent.click(first);
+  expect(todos.children.length).toBe(1);
+});
+

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom/extend-expect';


### PR DESCRIPTION
Fix error of "Tests cannot be nested. Test `displays initial to-dos` cannot run because it is nested within `Todo`"